### PR TITLE
fix invalid address

### DIFF
--- a/tags/pages/actor-edit.tag.html
+++ b/tags/pages/actor-edit.tag.html
@@ -26,7 +26,7 @@
         <input type=text name=mainPhone id=mainPhone value="{ this.actor && this.actor.mainPhone }">
 
         <label for=address>Adresse</label>
-        <input type=text name=address id=address value={ this.actor && this.actor.address } required>
+        <input type=text name=address id=address ref=address oninput={ this.setValidity } value={ this.actor && this.actor.address } required>
 
         <label for=city>Ville</label>
         <input type=text name=city id=city value={ this.actor && this.actor.city } required>
@@ -157,6 +157,8 @@
       this.actor.image = event.target.value
     }
 
+    this.setValidity = (event) => event.target.setCustomValidity('')
+
     this.on('mount', async () => {
       this.actor = actorId ? await api(`/actors/${actorId}`) : {}
       this.actions = this.actor && this.actor.actions ? this.actor.actions : [actionTemplate()]
@@ -168,10 +170,17 @@
       event.preventDefault()
 
       const data = new FormData(event.target)
+
+      // Try to get address.
       const apiAddress = 'https://api-adresse.data.gouv.fr/search/?limit=1&autocomplete=0'
       const addresses = await request(
         `${apiAddress}&q=${data.get('address')} ${data.get('city')}&postcode=${data.get('postalCode')}`)
       const address = addresses.features[0]
+      if (!address) {
+        this.refs.address.setCustomValidity('L‘adresse est invalide, veuillez la vérifier ou en essayer une autre.')
+        this.refs.address.reportValidity()
+        return
+      }
 
       function getActionProperty(name, index, isArray) {
         return data[isArray ? 'getAll' : 'get'](`action[${index}].${name}`)


### PR DESCRIPTION
Fix https://github.com/betagouv/eac/issues/43

J'ai utilisé `setCustomValidity` et `reportValidity` que je ne connaissaient pas et qui permettent d'avoir le même comportement que les `required`, pour éviter une nouvelle UI spéciale "champ invalide".

Cette PR évite un crash pas compréhensible en cas d'erreur sur l'adresse. J'ai essayé de donner deux pistes semblables, mais qui peuvent être interprétées différemment, dans le message d'erreur pour mieux guider les utilisateurs (mais je peux aussi le changer).

La ligne https://github.com/betagouv/eac/compare/fix-invalid-address?expand=1#diff-a94329a7f3cad9a073d9be5d3a22b9a2R160 me plait moyennement (mettre une chaine vide), mais il semble que ce soit l'état de l'art actuellement pour cette propriété pour désactiver l'invalidité.