### PR TITLE
search by address

### DIFF
--- a/js/src/app.js
+++ b/js/src/app.js
@@ -29,13 +29,13 @@ async function schoolById(id) {
     const [lng, lat] = id.split(',')
     const addresses = await request(`https://api-adresse.data.gouv.fr/reverse/?lon=${lng}&lat=${lat}&limit=1`)
     if (addresses.features) {
-      const f = addresses.features[0]
+      const feature = addresses.features[0]
       return Promise.resolve({
-        name: f.properties.label, 
-        city: f.properties.city.toUpperCase(),
-        postalCode: f.properties.postcode,
+        name: feature.properties.label, 
+        city: feature.properties.city.toUpperCase(),
+        postalCode: feature.properties.postcode,
         loc: {
-          coordinates: f.geometry.coordinates 
+          coordinates: feature.geometry.coordinates 
         }
       })
     }    

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -23,3 +23,22 @@ function urlParams(queryString = location.search) {
 function normalizeString (str) {
   return str.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
 }
+
+async function schoolById(id) {
+  if (id.includes(',')) {
+    const [lng, lat] = id.split(',')
+    const addresses = await request(`https://api-adresse.data.gouv.fr/reverse/?lon=${lng}&lat=${lat}&limit=1`)
+    if (addresses.features) {
+      const f = addresses.features[0]
+      return Promise.resolve({
+        name: f.properties.label, 
+        city: f.properties.city.toUpperCase(),
+        postalCode: f.properties.postcode,
+        loc: {
+          coordinates: f.geometry.coordinates 
+        }
+      })
+    }    
+  } 
+  return api(`/schools/${id}`)
+}

--- a/tags/pages/search.tag.html
+++ b/tags/pages/search.tag.html
@@ -48,9 +48,10 @@
 
     this.on('mount', async () => {
       let params = this.filters.domains ? `?domains=${this.domains}` : ''
+
       if (this.schoolId) {
-        this.school = await api(`/schools/${this.schoolId}`)
-        if (this.school.loc.coordinates) {
+        this.school = await schoolById(this.schoolId)
+        if (this.school.loc && this.school.loc.coordinates) {
           params += (params ? '&' : '?')
           params += `from=${this.school.loc.coordinates[1]},${this.school.loc.coordinates[0]}`
         }

--- a/tags/partials/actors-map.tag.html
+++ b/tags/partials/actors-map.tag.html
@@ -10,8 +10,9 @@
       let school = null
       let lngLat = [46.495, 2.207] // center of France
       let zoom = 6 // France overview
+
       if (this.schoolId) {
-        school = await api(`/schools/${this.schoolId}`)
+        school = await schoolById(this.schoolId)
         lngLat = school.loc.coordinates.reverse()
         zoom = 9
       }

--- a/tags/partials/select-school.tag.html
+++ b/tags/partials/select-school.tag.html
@@ -6,10 +6,10 @@
 
     this.displaySchool = (school) => `${school.name} (${school.postalCode} ${school.city})`
     
-    this.fromAddress = (f) => { 
+    this.fromAddress = (feature) => { 
       return {
-        label: `${f.properties.label} (${f.properties.postcode} ${f.properties.city.toUpperCase()})`, 
-        value: f.geometry.coordinates.join(',')
+        label: `${feature.properties.label} (${feature.properties.postcode} ${feature.properties.city.toUpperCase()})`, 
+        value: feature.geometry.coordinates.join(',')
       }
     }
 

--- a/tags/partials/select-school.tag.html
+++ b/tags/partials/select-school.tag.html
@@ -4,15 +4,20 @@
   <script>
     /* global api, Awesomplete, normalizeString */
 
-    this.displaySchool = (school) => {
-      return `${school.name} (${school.postalCode} ${school.city})`
+    this.displaySchool = (school) => `${school.name} (${school.postalCode} ${school.city})`
+    
+    this.fromAddress = (f) => { 
+      return {
+        label: `${f.properties.label} (${f.properties.postcode} ${f.properties.city.toUpperCase()})`, 
+        value: f.geometry.coordinates.join(',')
+      }
     }
 
     this.on('mount', async () => {
       let id = this.opts.schoolId
 
       if (id) {
-        const school = await api(`/schools/${id}`)
+        const school = await schoolById(id)
         this.refs.input.value = this.displaySchool(school)
       }
 
@@ -38,13 +43,21 @@
         if (!q || q.length < 3) {
           return
         }
-        const schools = await api(`/schools/search/${q}`)
-        completer.list = schools && schools.map(s => {
-          return {
-            label: this.displaySchool(s),
-            value: s._id
-          }
-        })
+
+        const [schools, addresses] = await Promise.all([
+          api(`/schools/search/${q}`),
+          request(`https://api-adresse.data.gouv.fr/search/?q=${q}&limit=1`)
+        ])
+
+        completer.list = [
+          ...schools.map(s => {
+            return {
+              label: this.displaySchool(s),
+              value: s._id
+            }
+          }), 
+          addresses.features && addresses.features[0] ? this.fromAddress(addresses.features[0]) : null
+        ].filter(x => x)
       })
 
       this.refs.input.addEventListener('awesomplete-selectcomplete', event => {


### PR DESCRIPTION
Gros changement.

Il est maintenant possible de rechercher par adresse (la recherche est libre, basée sur l'API https://adresse.data.gouv.fr/api). Cela signifie que dans le _awsomplete_, la première entrée est issue de data.gouv.fr (si un résultat est trouvé) et les suivantes de notre liste des établissement. À la place d'un numéro d'école, dans le cas où c'est une adresse, la longitude et la latitude sont utilisés.

**Note importante :** pour rendre cette PR lisible et reviewable, j'ai fait le choix _délibéré_ de ne pas renommer les instances du mot _`school`_ qui n'est pourtant plus exact. En effet, ce mot apparait à de très nombreux endroits dans le front et je ne _souhaitais_ pas le modifier, car je suis persuadé que ça rendrait la PR très difficile à lire. J'ai donc décidé de faire rentrer la recherche par adresse par la petite porte, de manière discrète. Cela signifie que je _devrais_ ensuite renommer les instances du mot _`school`_ pour les remplacer par _`location`_ mais je souhaite le faire dans une autre PR (cela induit des renommages de fichiers, de tags, de variables et de fonctions). Cette deuxième PR devrait alors être aussi simple à lire que celle là.

@vinyll à ta dispo pour discuter de cette PR ! J'ai essayé de faire minimal et je ne suis pas _trop_ mécontent.

Pour faire simple pour bien comprendre cette PR, j'ai remplacé les instances de ça :

```js
await api(`/schools/${this.schoolId}`)
```

Par ça (qui choisit soit dans les écoles dans notre API, soit dans l'API adresses si c'est des coordonnées) : 

```js
await schoolById(this.schoolId)
```