### PR TITLE
fix school search

### DIFF
--- a/tags/partials/select-school.tag.html
+++ b/tags/partials/select-school.tag.html
@@ -58,6 +58,9 @@
           }), 
           addresses.features && addresses.features[0] ? this.fromAddress(addresses.features[0]) : null
         ].filter(x => x)
+        if (completer.suggestions.length) {
+          this.schoolId = completer.suggestions[0].value
+        }
       })
 
       this.refs.input.addEventListener('awesomplete-selectcomplete', event => {


### PR DESCRIPTION
J'ai créé une PR pour avoir ton avis.

Actuellement, si je fais une recherche dans la partie "lieu" et que je ne sélectionne pas un endroit dans le awesomeplete, rien n'est pris en compte et ça prend tout la France. Donc si je tape "Nantes" dans la boite et que je clique sur "rechercher" ou que j'appuie sur "entrée" ça me renvoie les actions de cannes et martigues.

J'ai fixé le truc en forçant à chaque input (chaque touche pressée) la valeur de recherche au premier élément (donc ça "sélectionne" implicitement le premier résultat tout le temps).

Je trouve que le résultat est plutôt cool pour gérer ce bug qu'on se traine depuis un bout de temps, mais c'est une demi-bidouille donc je te laisse la valider.

PS: j'ai testé d'autres approches qui n'ont rien donné.